### PR TITLE
chore(release): let release-drafter maintain drafts for humans to publish

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Release Drafter
 
 on:
   push:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   update_release_draft:
     uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v13.1.0

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -9,5 +9,4 @@ jobs:
   update_release_draft:
     uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v13.1.0
     secrets:
-      app_id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
-      private_key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}
+      token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,16 +2,17 @@ name: Release
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 jobs:
   update_release_draft:
     uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v13.1.0
-    with:
-      publish: true
-      name: ${{ github.ref_name }}
-      tag: ${{ github.ref_name }}
     secrets:
       app_id: ${{ vars.STAFFBASE_ACTIONS_APP_ID }}
       private_key: ${{ secrets.STAFFBASE_ACTIONS_PRIVATE_KEY }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,11 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 jobs:
   update_release_draft:


### PR DESCRIPTION
### Type of Change

- [ ] Bugfix
- [ ] Enhancement / new feature
- [x] Refactoring
- [ ] Documentation

### Description

Inverts the release flow. Previously a human had to push a tag, which then triggered `release-drafter` with `publish: true` to create the GitHub Release immediately. Going forward, `release-drafter` runs on every push to `main` to keep a **draft** release continuously up to date. A human then publishes that draft via the GitHub Releases UI when the next version is ready to ship.

Concretely, `.github/workflows/release.yaml` now:

- triggers on `push` to `main` instead of on tag pushes
- drops the `publish: true`, `name` and `tag` inputs so the reusable Staffbase template falls back to its default (`publish: false`), which is exactly the draft behaviour we want

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](https://github.com/Staffbase/yamllint-action/blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging

---
<sub>The changes and the PR were generated by Claude.</sub>