### PR TITLE
fix(release-drafter): add version templates and resolver

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,3 +1,22 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'feature'
+      - 'enhancement'
+  patch:
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+      - 'chore'
+      - 'dependencies'
+      - 'documentation'
+  default: patch
 categories:
   - title: '🚀 Features'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -11,7 +11,6 @@ version-resolver:
   patch:
     labels:
       - 'fix'
-      - 'bugfix'
       - 'bug'
       - 'chore'
       - 'dependencies'

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ Add a status label if the merge was successful or failed.
 
 # Release
 
-You can create a new release by creating a new tag and bump the version in `package.json.`
+Releases are maintained continuously by [Release Drafter](https://github.com/release-drafter/release-drafter). On every push to `main`, the open draft on the [Releases page](https://github.com/Staffbase/autodev-action/releases) is rebuilt from merged pull requests, with the next version (`vX.Y.Z`) resolved from PR labels (see `.github/release-drafter.yml` for the mapping).
+
+When the draft is ready to ship, open it on the Releases page and click **Publish release**. The tag is created at publish time. Remember to bump the `version` field in `package.json` in a follow-up PR so it matches the published tag.
 
 # Development
 


### PR DESCRIPTION
### Type of Change

- [x] Bugfix
- [ ] Enhancement / new feature
- [ ] Refactoring
- [ ] Documentation

### Description

After #406 switched the release workflow from a tag-push (with explicit `publish: true`, `name: ${{ github.ref_name }}`, `tag: ${{ github.ref_name }}` inputs) to a continuous draft model triggered on `push: main`, release-drafter is now responsible for computing the next version itself. The config in `.github/release-drafter.yml` was missing `name-template`, `tag-template`, and `version-resolver`, so the latest run produced an empty draft (`untagged-a75edd174a086d69cb7d`) without title or tag, breaking the established `vX.Y.Z` naming scheme of all prior releases up to `v2.7.0`.

This PR restores the previous naming scheme by adding:

- `name-template` / `tag-template` rendering as `v$RESOLVED_VERSION`
- a `version-resolver` mapping the labels already consumed by the `categories` section to semver bumps (`feature`/`enhancement` → minor, `fix`/`bugfix`/`bug`/`chore`/`dependencies`/`documentation` → patch, `breaking` → major), with `default: patch`

The Dependabot `major` label is intentionally not part of the resolver: in PR labels it indicates the dependency's bump level, not a major release of this action. Real major bumps are reserved for the manually applied `breaking` label.

With these settings, the next draft will be calculated as `v2.7.1` based on the currently merged `fix:`/`chore:`/dependency PRs since `v2.7.0`.

### Checklist

- [ ] Write tests
- [ ] Make sure all tests pass
- [ ] Update documentation
- [x] Review the [Contributing Guideline](https://github.com/Staffbase/yamllint-action/blob/main/CONTRIBUTING.md) and sign CLA
- [ ] Reference relevant issue(s) and close them after merging

### Follow-up

The existing empty draft (`untagged-a75edd174a086d69cb7d`) will not be reused by release-drafter and should be deleted manually so the next workflow run can create a fresh, correctly named draft.

---
<sub>The changes and the PR were generated by Claude.</sub>