### PR TITLE
chore: pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/check-dist.yml
+++ b/.github/workflows/check-dist.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install Dependencies
         run: mise run install
@@ -42,7 +42,7 @@ jobs:
         id: diff
 
       # If index.cjs was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: ${{ failure() && steps.diff.conclusion == 'failure' }}
         with:
           name: dist

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request'
-        uses: cla-assistant/github-action@v2.6.1
+        uses: cla-assistant/github-action@ca4a40a7d1004f18d9960b404b97e5f30a505a08 # v2.6.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PERSONAL_ACCESS_TOKEN: ${{ secrets.OSS_CONTRIBUTOR_LICENSE_AGREEMENT }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up mise
-        uses: jdx/mise-action@v4
+        uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4
 
       - name: Install Dependencies
         run: mise run install
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Execute Action
         uses: ./
@@ -41,7 +41,7 @@ jobs:
 
   dependabot:
     needs: [build, test]
-    uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@v13.4.1
+    uses: Staffbase/gha-workflows/.github/workflows/template_automerge_dependabot.yml@9ea5ca06a1ef865b0af9745b47ea74b731b65fc5 # v13.4.1
     with:
       force: true
     secrets:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,6 +12,6 @@ permissions:
 
 jobs:
   update_release_draft:
-    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@v13.4.1
+    uses: Staffbase/gha-workflows/.github/workflows/template_release_drafter.yml@9ea5ca06a1ef865b0af9745b47ea74b731b65fc5 # v13.4.1
     secrets:
       token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Type of Change

- [x] Enhancement / new feature

### Description

Pins every third-party GitHub Action reference in this repo to a full 40-character commit SHA, with the human-readable version tag preserved as a trailing comment. This implements the org-wide policy from [advisory-space ADR 0006 — SHA Pinning for GitHub Actions](https://github.com/Staffbase/advisory-space/blob/main/docs/adrs/tools-datamgmt/0006-gha-sha-pinning.md).

**Why:** Mutable tags (`@v4`, `@v2.6.1`) can be silently moved or rewritten by a maintainer or an attacker with repo access. The `tj-actions/changed-files` and `codecov/codecov-action` supply-chain compromises in 2025 showed that consumers pinning to tags executed tampered code without any change to their workflow files. A commit SHA is immutable; pinning to it guarantees the exact code that runs.

Pinned references:

- `actions/checkout` → `df4cb1c069e1874edd31b4311f1884172cec0e10` (v6)
- `jdx/mise-action` → `1648a7812b9aeae629881980618f079932869151` (v4)
- `actions/upload-artifact` → `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` (v7)
- `cla-assistant/github-action` → `ca4a40a7d1004f18d9960b404b97e5f30a505a08` (v2.6.1)
- `Staffbase/gha-workflows/.../template_automerge_dependabot.yml` → `9ea5ca06a1ef865b0af9745b47ea74b731b65fc5` (v13.4.1)
- `Staffbase/gha-workflows/.../template_release_drafter.yml` → `9ea5ca06a1ef865b0af9745b47ea74b731b65fc5` (v13.4.1)

The local `uses: ./` reference in `integration.yml` is left untouched (not a third-party reference). Dependabot is already configured for the `github-actions` ecosystem in `.github/dependabot.yml` and will keep these SHAs current.

### Checklist

- [x] Review the [Contributing Guideline](https://github.com/Staffbase/yamllint-action/blob/main/CONTRIBUTING.md) and sign CLA

---
<sub>The changes and the PR were generated by Claude.</sub>